### PR TITLE
chore: bump package version to 0.0.0 in pyproject.toml and workspace

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,11 @@
 [project]
 name = "satelles"
-version = "0.1.0"
+version = "0.0.0"
 description = "Add your description here"
 readme = "README.md"
 authors = [{ name = "michealroberts", email = "michael@observerly.com" }]
 requires-python = ">=3.13"
-dependencies = [
-    "pydantic>=2.10.6",
-]
+dependencies = ["pydantic>=2.10.6"]
 
 [build-system]
 requires = ["hatchling"]

--- a/uv.lock
+++ b/uv.lock
@@ -374,7 +374,7 @@ wheels = [
 
 [[package]]
 name = "satelles"
-version = "0.1.0"
+version = "0.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
chore: bump package version to 0.0.0 in pyproject.toml and workspace