### PR TITLE
refactor!: amend get_modified_julian_date_from_parts to return MJD as float in satelles module

### DIFF
--- a/src/satelles/mjd.py
+++ b/src/satelles/mjd.py
@@ -34,7 +34,7 @@ def convert_mjd_to_datetime(mjd: float) -> datetime:
 # **************************************************************************************
 
 
-def get_modified_julian_date_from_parts(mjd: Tuple[int, float]) -> datetime:
+def get_modified_julian_date_from_parts(mjd: Tuple[int, float]) -> float:
     """
     Convert a tuple of (days, seconds) representing Modified Julian Date (MJD)
     to a UTC datetime object.
@@ -47,7 +47,7 @@ def get_modified_julian_date_from_parts(mjd: Tuple[int, float]) -> datetime:
     """
     days, seconds = mjd
 
-    return MJD_EPOCH_AS_DATETIME + timedelta(days=days, seconds=seconds)
+    return days + (seconds / 86400.0)
 
 
 # **************************************************************************************

--- a/test/test_mjd.py
+++ b/test/test_mjd.py
@@ -83,50 +83,32 @@ class TestConvertMJDToDatetime(unittest.TestCase):
 class TestGetModifiedJulianDateFromParts(unittest.TestCase):
     def test_epoch_parts(self):
         """(0 days, 0 seconds) should return the MJD epoch."""
-        dt = get_modified_julian_date_from_parts((0, 0.0))
-        self.assertEqual(dt, MJD_EPOCH_AS_DATETIME)
+        MJD = get_modified_julian_date_from_parts((0, 0.0))
+        self.assertEqual(MJD, 0.0)
 
     def test_half_day_offset(self):
         """
         (0 days, 43200 seconds) should return epoch + 0.5 days (i.e., 12:00 UTC on
         the epoch date).
         """
-        dt = get_modified_julian_date_from_parts((0, 43200.0))
-        expected = MJD_EPOCH_AS_DATETIME + timedelta(hours=12)
-        self.assertEqual(dt, expected)
-        self.assertEqual(dt.hour, 12)
-        self.assertEqual(dt.minute, 0)
-        self.assertEqual(dt.second, 0)
-        self.assertEqual(dt.microsecond, 0)
+        MJD = get_modified_julian_date_from_parts((0, 43200.0))
+        expected = 0.5
+        self.assertEqual(MJD, expected)
 
     def test_large_mjd_parts(self):
         """Test a large MJD (e.g., 59349, 0.0) against a known reference."""
-        dt = get_modified_julian_date_from_parts((59349, 0.0))
-        expected = MJD_EPOCH_AS_DATETIME + timedelta(days=59349.0)
-        self.assertEqual(dt, expected)
-        self.assertEqual(dt.year, 2021)
-        self.assertEqual(dt.month, 5)
-        self.assertEqual(dt.day, 15)
-        self.assertEqual(dt.hour, 0)
-        self.assertEqual(dt.minute, 0)
-        self.assertEqual(dt.second, 0)
-        self.assertEqual(dt.microsecond, 0)
+        MJD = get_modified_julian_date_from_parts((59349, 0.0))
+        expected = 59349.0
+        self.assertEqual(MJD, expected)
 
     def test_fractional_seconds_of_day_parts(self):
         """
         Test a large fractional MJD (e.g., 59349, 43200.0) to ensure it returns the
-        correct datetime.
+        correct MJD value.
         """
-        dt = get_modified_julian_date_from_parts((59349, 43200.895))
-        expected = MJD_EPOCH_AS_DATETIME + timedelta(days=59349.0, seconds=43200.895)
-        self.assertEqual(dt, expected)
-        self.assertEqual(dt.year, 2021)
-        self.assertEqual(dt.month, 5)
-        self.assertEqual(dt.day, 15)
-        self.assertEqual(dt.hour, 12)
-        self.assertEqual(dt.minute, 0)
-        self.assertEqual(dt.second, 0)
-        self.assertEqual(dt.microsecond, 895000)
+        MJD = get_modified_julian_date_from_parts((59349, 43200.895))
+        expected = 59349.5
+        self.assertAlmostEqual(MJD, expected, places=1)
 
 
 # **************************************************************************************


### PR DESCRIPTION
refactor!: amend get_modified_julian_date_from_parts to return MJD as float in satelles module